### PR TITLE
jhash: use length parameter instead of slice length

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,21 +1,22 @@
 use ::jhash::{jhash_final, jhash_mix, JHASH_INITVAL};
 
 #[must_use]
-pub fn jhash(mut key: &[u8], length: u32, initval: u32) -> u32 {
+pub fn jhash(mut key: &[u8], mut length: u32, initval: u32) -> u32 {
     let mut a = JHASH_INITVAL.wrapping_add(length).wrapping_add(initval);
     let mut b = a;
     let mut c = a;
 
-    while key.len() > 12 {
+    while length > 12 {
         use std::convert::TryInto;
         a = a.wrapping_add(u32::from_ne_bytes(key[..4].try_into().unwrap()));
         b = b.wrapping_add(u32::from_ne_bytes(key[4..8].try_into().unwrap()));
         c = c.wrapping_add(u32::from_ne_bytes(key[8..12].try_into().unwrap()));
         jhash_mix(&mut a, &mut b, &mut c);
         key = &key[12..];
+        length -= 12;
     }
 
-    if key.is_empty() {
+    if length == 0 {
         return c;
     }
 


### PR DESCRIPTION
 Fixes to_id failing for strings with byte length divisible by 12

Fixes Issue #3 